### PR TITLE
Comment Out the Sponsorship Logo Section of the Old Website

### DIFF
--- a/sponsorships.html
+++ b/sponsorships.html
@@ -123,10 +123,11 @@
 
         <section>
             <div class="container-fluid wide-screen-support">
-                <div class="mt-5">
+                <!--div class="mt-5">
                     <h2 class="text-center">Who We've Worked With</h2>
-                </div>
-                <div class="sponsorship-logo-container dark_gray_background">
+                </div-->
+                <!--div class="sponsorship-logo-container dark_gray_background">
+
                     <div class="row">
                         <div
                             class="col-6 col-md-4 col-lg-3 sponsor-logo-pic-block"
@@ -226,7 +227,7 @@
                             </a>
                         </div>
                     </div>
-                </div>
+                </div-->
             </div>
         </section>
         <section class="container-fluid gray_background">


### PR DESCRIPTION
With the recent discussion with Skyler (our financial point of contact for ordering materials) about using copyrighted logos from vendors on our stuff, she explained that using the logos without permission can result in a hefty fine for our club.

We have not had sponsors for a while due to Covid, and in order to be cautious, I removed the current sponsorship logos from the current old website. I would rather not have the club's reputation be hit until we get permission. 

This removes the "Who We've Worked With" section. 

We will also have to remove the logos from the new website as well when the time comes to migrate to the new website. 